### PR TITLE
feat: 이메일 인증 코드 발급/확인  API 연동

### DIFF
--- a/src/apis/auth/register.ts
+++ b/src/apis/auth/register.ts
@@ -1,0 +1,40 @@
+import axios from 'axios';
+import { instance } from '../instance';
+import {
+  type EmailVerificationRequest,
+  type ApiError,
+  EmailVerificationResponse,
+} from '@/types/auth';
+
+//   이메일 인증 코드 발급
+export const requestEmailVerification = async (email: string) => {
+  try {
+    const response = await instance.post<void>('/auth/register/email/request', {
+      email,
+    });
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response?.data) {
+      throw error.response.data as ApiError;
+    }
+    throw error;
+  }
+};
+
+//   이메일 인증 코드 확인
+export const verifyEmailCode = async (email: string, code: string) => {
+  try {
+    // console.log('Request Data:', { email, code });
+    const response = await instance.post<EmailVerificationResponse>(
+      '/auth/register/email/verify',
+      { email, code },
+    );
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response?.data) {
+      console.log('Error Response:', error.response?.data);
+      throw error.response.data as ApiError;
+    }
+    throw error;
+  }
+};

--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -1,0 +1,8 @@
+import axios from 'axios';
+
+export const instance = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_URL,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -4,17 +4,33 @@ import { ChevronLeft } from 'lucide-react';
 import { Input } from '@/components/ui/Input/Input';
 import { useRouter } from 'next/navigation';
 import { FormEvent, useState } from 'react';
+import { requestEmailVerification } from '@/apis/auth/register';
+import { getAuthErrorMessage } from '@/utils/handle-error';
+import type { ApiError } from '@/types/auth';
 
 export default function SignUpPage() {
   const router = useRouter();
   const [email, setEmail] = useState('');
+  const [error, setError] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
 
-  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    // TODO: 회원가입 이메일 검증 로직 구현
-    if (email) {
-      localStorage.setItem('tempEmail', email);
+    setError('');
+    setIsLoading(true);
+
+    try {
+      await requestEmailVerification(email);
+      console.log('Redirecting with email:', email);
       router.push(`/verify/email/sent?email=${encodeURIComponent(email)}`);
+    } catch (error) {
+      if ('code' in (error as any)) {
+        setError(getAuthErrorMessage(error as ApiError));
+      } else {
+        setError('인증 메일 발송에 실패했습니다. 잠시 후 다시 시도해주세요.');
+      }
+    } finally {
+      setIsLoading(false);
     }
   };
 
@@ -40,22 +56,28 @@ export default function SignUpPage() {
 
         {/* 폼 영역 */}
         <form onSubmit={handleSubmit}>
-          <div className="mb-5">
-            <label className="block text-[16px] text-black mb-3">email</label>
+          <div className="space-y-2">
+            <div className="flex justify-between items-center mb-3">
+              <label className="text-[16px] text-black">email</label>
+              {error && <p className="text-[14px] text-[#FF3D5E]">{error}</p>}
+            </div>
             <Input
               type="email"
               placeholder="Mohaji@naver.com"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
+              disabled={isLoading}
               required
+              className={`w-full ${error ? 'border-[#FF3D5E] border' : ''}`}
             />
           </div>
 
           <button
             type="submit"
-            className="w-full h-[48px] bg-[#0A0A0A] text-white rounded-lg hover:opacity-90 mb-[60px]"
+            className="w-full h-[48px] bg-[#0A0A0A] text-white rounded-lg hover:opacity-90 mt-[60px] disabled:opacity-50 disabled:cursor-not-allowed"
+            disabled={isLoading}
           >
-            다음
+            {isLoading ? '처리중...' : '다음'}
           </button>
         </form>
       </div>

--- a/src/app/(auth)/verify/email/page.tsx
+++ b/src/app/(auth)/verify/email/page.tsx
@@ -2,25 +2,46 @@
 
 import { ChevronLeft } from 'lucide-react';
 import { Input } from '@/components/ui/Input/Input';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { FormEvent, useState } from 'react';
+import { verifyEmailCode } from '@/apis/auth/register';
+import { getAuthErrorMessage } from '@/utils/handle-error';
+import { ApiError } from '@/types/auth';
 
 export default function EmailVerificationPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+
   const [verificationCode, setVerificationCode] = useState('');
   const [error, setError] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const email = searchParams.get('email') || '';
 
-  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    // TODO: 인증 코드 검증 로직 구현
-    // 테스트용
-    if (verificationCode === '123456') {
-      localStorage.setItem('isVerified', 'true');
+    setError('');
+    setIsLoading(true);
+
+    try {
+      const response = await verifyEmailCode(email, verificationCode);
+
+      // 토큰 저장
+      localStorage.setItem('accessToken', response.accessToken);
+      localStorage.setItem('refreshToken', response.refreshToken);
+
+      // 비밀번호 설정 페이지로 이동
       router.push('/signup/password');
-    } else {
-      setError('인증코드가 일치하지 않습니다.');
+    } catch (error) {
+      if ('code' in (error as any)) {
+        setError(getAuthErrorMessage(error as ApiError));
+      } else {
+        setError('인증에 실패했습니다. 잠시 후 다시 시도해주세요.');
+      }
+    } finally {
+      setIsLoading(false);
     }
   };
+
   const handleResend = () => {
     // 재전송 버튼 클릭 시 메시지만 표시(테스트)
     setVerificationCode('');
@@ -55,39 +76,39 @@ export default function EmailVerificationPage() {
         </div>
 
         <form onSubmit={handleSubmit}>
-          <div className="relative">
-            {' '}
+          <div className="space-y-2">
+            <div className="flex justify-between items-center mb-3">
+              <label className="text-[16px] text-black">인증코드</label>
+              {error && <p className="text-[14px] text-[#FF3D5E]">{error}</p>}
+            </div>
             <div className="flex gap-2">
               <Input
                 type="text"
                 placeholder="123456"
                 value={verificationCode}
-                onChange={handleChange}
+                onChange={(e) => setVerificationCode(e.target.value)}
                 maxLength={6}
                 required
                 className={`w-[206px] h-[39px] ${error ? 'border-[#FF3D5E]' : ''}`}
+                disabled={isLoading}
               />
               <button
                 type="button"
                 onClick={handleResend}
                 className="w-[82px] h-[39px] bg-[#1E96FF] text-white rounded-lg hover:opacity-90 text-[14px]"
+                disabled={isLoading}
               >
                 재전송
               </button>
             </div>
-            {/* 에러 메시지 */}
-            {error && (
-              <p className="absolute top-[45px] left-0 text-[14px] text-[#FF3D5E]">
-                {error}
-              </p>
-            )}
           </div>
 
           <button
             type="submit"
-            className="w-full h-[48px] bg-[#0A0A0A] text-white rounded-lg hover:opacity-90 mt-[60px]"
+            className="w-full h-[48px] bg-[#0A0A0A] text-white rounded-lg hover:opacity-90 mt-[60px] disabled:opacity-50 disabled:cursor-not-allowed"
+            disabled={isLoading}
           >
-            확인
+            {isLoading ? '처리중...' : '확인'}
           </button>
         </form>
       </div>

--- a/src/app/(auth)/verify/email/sent/page.tsx
+++ b/src/app/(auth)/verify/email/sent/page.tsx
@@ -9,7 +9,7 @@ export default function EmailSentPage() {
   const email = searchParams.get('email') || localStorage.getItem('tempEmail');
 
   const handleConfirm = () => {
-    router.push('/verify/email');
+    router.push(`/verify/email?email=${encodeURIComponent(email || '')}`);
   };
 
   return (

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,38 @@
+export interface EmailVerificationRequest {
+  email: string;
+}
+
+export interface EmailVerificationResponse {
+  accessToken: string;
+  refreshToken: string;
+}
+
+export interface EmailVerifyRequest {
+  email: string;
+  code: string;
+}
+
+export interface ApiError {
+  code: string;
+  message: string;
+}
+
+{
+  /* 에러 코드 상수 */
+}
+export const AUTH_ERROR_CODES = {
+  // 이미 회원가입을 마친 유저인 경우: 400
+  EXISTING_USER: 'R0001',
+
+  // 이미 24시간 동안 3번의 이메일 인증 요청을 보냈을 경우 : 400
+  VERIFICATION_LIMIT_EXCEEDED: 'EV004',
+
+  // 인증 메일 요청에 실패했을 경우 : 500
+  EMAIL_SEND_FAILED: 'EV0001',
+
+  // 인증 코드 발급이 만료됐거나 인증 코드를 발급한 적이 없는 경우 : 400
+  INVALID_EMAIL: 'EV0002',
+
+  // 인증 코드 입력에 5회 이상 실패했을 경우 : 400
+  VERIFICATION_ATTEMPT_EXCEEDED: 'EV0003',
+} as const;

--- a/src/utils/handle-error.ts
+++ b/src/utils/handle-error.ts
@@ -1,0 +1,23 @@
+import { ApiError, AUTH_ERROR_CODES } from '@/types/auth';
+
+export const getAuthErrorMessage = (error: ApiError): string => {
+  switch (error.code) {
+    case AUTH_ERROR_CODES.EXISTING_USER:
+      return '이미 가입된 이메일입니다.';
+
+    case AUTH_ERROR_CODES.VERIFICATION_LIMIT_EXCEEDED:
+      return '인증 메일 발송 횟수를 초과했습니다. (24시간 후 다시 시도해주세요)';
+
+    case AUTH_ERROR_CODES.EMAIL_SEND_FAILED:
+      return '인증 메일 발송에 실패했습니다. 잠시 후 다시 시도해주세요.';
+
+    case AUTH_ERROR_CODES.INVALID_EMAIL:
+      return '인증 코드가 만료되었거나 유효하지 않습니다.';
+
+    case AUTH_ERROR_CODES.VERIFICATION_ATTEMPT_EXCEEDED:
+      return '인증 시도 횟수를 초과했습니다.';
+
+    default:
+      return '알 수 없는 에러가 발생했습니다.';
+  }
+};


### PR DESCRIPTION
# 이메일 인증 API 연동

## 구현 내용
- 이메일 인증 관련 API 연동
  - POST : /auth/register/email/request 이메일 인증 코드 발급
  - POST : /auth/register/email/verify 이메일 인증 코드 확인

- API 상태 처리
  - 로딩 상태 UI 구현
  - API 에러 처리 및 에러 메시지 표시(handle-error.ts)
  - 에러 코드 상수 추가(auth.ts)