### PR TITLE
fix: 게시글 목록 날짜 기반 정렬 및 중복 제거

### DIFF
--- a/src/components/blog/PostListClient.tsx
+++ b/src/components/blog/PostListClient.tsx
@@ -15,7 +15,13 @@ export default function PostListClient({
   initialData,
   searchParams,
 }: PostListClientProps) {
-  const [posts, setPosts] = useState<Post[]>(initialData.content);
+  const [posts, setPosts] = useState<Post[]>(
+    initialData.content.sort((a, b) => {
+      const dateA = new Date(a.publishedAt || a.createdAt);
+      const dateB = new Date(b.publishedAt || b.createdAt);
+      return dateB.getTime() - dateA.getTime();
+    }),
+  );
   const [page, setPage] = useState(0);
   const [hasMore, setHasMore] = useState(!initialData.last);
 
@@ -35,7 +41,18 @@ export default function PostListClient({
             : undefined,
       });
 
-      setPosts((prev) => [...prev, ...response.content]);
+      setPosts((prev) => {
+        const newPosts = response.content.filter(
+          (newPost) =>
+            !prev.some((existingPost) => existingPost.id === newPost.id),
+        );
+        return [...prev, ...newPosts].sort((a, b) => {
+          const dateA = new Date(a.publishedAt || a.createdAt);
+          const dateB = new Date(b.publishedAt || b.createdAt);
+          return dateB.getTime() - dateA.getTime();
+        });
+      });
+
       setPage(nextPage);
       setHasMore(!response.last);
     } catch (error) {


### PR DESCRIPTION
fix: 게시글 목록 날짜 기반 정렬 및 중복 제거

- 게시글 목록 publishedAt/createdAt 기준 최신순 정렬 추가
- 중복 게시글 제거 로직 구현