### PR TITLE
refactor: 프로필 이미지, 헤더, 게시글 카드 리팩토링 및 UI 개선

### DIFF
--- a/src/components/blog/BlogPostCard.tsx
+++ b/src/components/blog/BlogPostCard.tsx
@@ -10,51 +10,49 @@ interface BlogPostCardProps {
 
 export default function BlogPostCard({ post }: BlogPostCardProps) {
   return (
-    <article className="bg-white rounded-2xl overflow-hidden shadow-sm">
-      {/* 썸네일 이미지 */}
-      {post.thumbnail && (
-        <div className="relative w-full h-[400px]">
-          <Image
-            src={post.thumbnail}
-            alt={post.title}
-            fill
-            className="object-cover"
-            priority
-          />
+    <Link href={`/posts/${post.id}`}>
+      <article className="bg-white rounded-2xl overflow-hidden shadow-[0px_0px_8px_0px_rgba(0,0,0,0.02)] hover:bg-[#F7F8FA] transition-colors">
+        {/* 썸네일 이미지 */}
+        {post.thumbnail && (
+          <div className="relative w-full h-[400px]">
+            <Image
+              src={post.thumbnail}
+              alt={post.title}
+              fill
+              className="object-cover"
+              priority
+            />
+          </div>
+        )}
+
+        {/* 컨텐츠 영역 */}
+        <div className="p-8">
+          {/* 제목 */}
+          <h2 className="text-2xl font-bold mb-2">{post.title}</h2>
+
+          {/* 날짜 */}
+          <time className="block text-[#666666] mb-4">
+            {post.publishedAt
+              ? formatDate(post.publishedAt)
+              : formatDate(post.createdAt)}
+          </time>
+
+          {/* 요약 */}
+          <p className="text-[#4D4D4D] mb-6">{post.summary}</p>
+
+          {/* 태그 목록 */}
+          <div className="flex flex-wrap gap-2">
+            {post.tags?.map((tag) => (
+              <span
+                key={tag.id}
+                className="px-4 py-2 bg-[#E4E6EB] text-[#666666] rounded-full text-sm"
+              >
+                {tag.title}
+              </span>
+            ))}
+          </div>
         </div>
-      )}
-
-      {/* 컨텐츠 영역 */}
-      <div className="p-8">
-        {/* 제목 */}
-        <Link href={`/posts/${post.id}`}>
-          <h2 className="text-2xl font-bold mb-2 hover:text-[#FF8C42] transition-colors">
-            {post.title}
-          </h2>
-        </Link>
-
-        {/* 날짜 */}
-        <time className="block text-[#666666] mb-4">
-          {post.publishedAt
-            ? formatDate(post.publishedAt)
-            : formatDate(post.createdAt)}
-        </time>
-
-        {/* 요약 */}
-        <p className="text-[#4D4D4D] mb-6">{post.summary}</p>
-
-        {/* 태그 목록 */}
-        <div className="flex flex-wrap gap-2">
-          {post.tags?.map((tag) => (
-            <span
-              key={tag.id}
-              className="px-4 py-2 bg-[#E4E6EB] text-[#666666] rounded-full text-sm"
-            >
-              {tag.title}
-            </span>
-          ))}
-        </div>
-      </div>
-    </article>
+      </article>
+    </Link>
   );
 }

--- a/src/components/common/ProfileImage.tsx
+++ b/src/components/common/ProfileImage.tsx
@@ -1,36 +1,38 @@
+import Image from 'next/image';
+
 interface ProfileImageProps {
-  nickname?: string;
+  src?: string | null;
+  alt?: string;
   size?: number;
+  className?: string;
 }
 
 export default function ProfileImage({
-  nickname = 'Anonymous',
-  size = 40,
+  src,
+  alt = '프로필',
+  size = 32,
+  className = '',
 }: ProfileImageProps) {
-  const colorMap = [
-    'bg-red-500',
-    'bg-blue-500',
-    'bg-green-500',
-    'bg-yellow-500',
-    'bg-purple-500',
-    'bg-pink-500',
-    'bg-indigo-500',
-  ];
-
-  // 사용자 이름을 기반으로 일관된 색상 선택
-  const colorIndex =
-    nickname.split('').reduce((acc, char) => acc + char.charCodeAt(0), 0) %
-    colorMap.length;
-
   return (
-    <div
-      className={`relative rounded-full overflow-hidden ${colorMap[colorIndex]}`}
-      style={{ width: size, height: size }}
-    >
-      {/* 프로필 이미지가 있는 경우 */}
-      <div className="flex items-center justify-center w-full h-full text-white font-bold">
-        {nickname.charAt(0).toUpperCase()}
-      </div>
+    <div className={`relative group ${className}`}>
+      {src ? (
+        <Image
+          src={src}
+          alt={alt}
+          width={size}
+          height={size}
+          className="w-full h-full object-cover rounded-full"
+        />
+      ) : (
+        <Image
+          src="/icon/Profile_Default_img@2x.svg"
+          alt={alt}
+          width={size}
+          height={size}
+          className="w-full h-full object-cover rounded-full"
+        />
+      )}
+      <div className="absolute inset-0 bg-black opacity-0 group-hover:opacity-40 transition-opacity duration-200 rounded-full" />
     </div>
   );
 }

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -43,14 +43,13 @@ export default function Header() {
           </Link>
         </div>
 
-        {/* 오른쪽 영역 (Developers 섹션과 동일한 width) */}
+        {/* 오른쪽 영역 */}
         <div className="w-[29%] flex justify-end">
           <div className="flex items-center gap-4">
-            {/* 글쓰기 버튼은 로그인 상태일 때만 표시하고 /write로 이동 */}
             {auth.isLoggedIn && (
               <Link
                 href="/write"
-                className="p-2 rounded-full hover:bg-[#000000] hover:bg-opacity-40 transition-all"
+                className="w-8 h-8 flex items-center justify-center rounded-full hover:bg-black hover:bg-opacity-40 transition-all"
               >
                 <Image
                   src="/icon/Edit.svg"
@@ -64,34 +63,17 @@ export default function Header() {
             {auth.isLoggedIn ? (
               <div className="relative">
                 <button
-                  className="w-8 h-8 rounded-full overflow-hidden group transition-all"
+                  className="w-8 h-8 rounded-full overflow-hidden hover:bg-black hover:bg-opacity-40 transition-all"
                   onClick={() => setIsDropdownOpen(!isDropdownOpen)}
                 >
-                  <div className="w-full h-full">
-                    {auth.userInfo?.profileImage ? (
-                      <img
-                        src={auth.userInfo.profileImage}
-                        alt="프로필"
-                        className="w-full h-full object-cover"
-                      />
-                    ) : (
-                      <div className="flex items-center justify-center w-full h-full bg-gray-100 group-hover:bg-[#000000] group-hover:bg-opacity-40">
-                        <Image
-                          src="/icon/User.svg"
-                          alt="프로필"
-                          width={24}
-                          height={24}
-                        />
-                      </div>
-                    )}
-                  </div>
+                  <ProfileImage src={auth.userInfo?.profileImage} size={32} />
                 </button>
                 {isDropdownOpen && <ProfileDropdown onLogout={handleLogout} />}
               </div>
             ) : (
               <Link
                 href="/login"
-                className="p-2 rounded-full hover:bg-black/40 transition-all"
+                className="w-8 h-8 flex items-center justify-center rounded-full hover:bg-black hover:bg-opacity-40 transition-all"
               >
                 <Image
                   src="/icon/Login.svg"


### PR DESCRIPTION
## 변경 사항
### ProfileImage 컴포넌트 리팩토링
- 중복 코드 제거를 위한 ProfileImage 컴포넌트 개선
- 기본 프로필 이미지를 Profile_Default_img@2x.svg로 통일
- hover 시 검은색 오버레이(opacity 40%) 효과 추가

### UI 상호작용 개선
- 게시글 카드 hover 효과 추가
  - 배경색 #F7F8FA로 변경
  - Contact 컴포넌트와 동일한 hover 효과 적용
- 헤더 UI 일관성 향상
  - 아이콘(글쓰기, 프로필, 로그인) 크기 32x32로 통일
  - hover 효과 통일 (검은색 배경, opacity 40%)

## 테스트 항목
- [ ] ProfileImage 컴포넌트 정상 동작 확인
  - 기본 이미지 표시
  - hover 효과 동작
- [ ] 게시글 카드 hover 효과 확인
- [ ] 헤더 아이콘들의 크기와 hover 효과 확인

## 변경된 파일
- src/components/common/ProfileImage.tsx
- src/components/blog/BlogPostCard.tsx
- src/components/layout/Header.tsx