### PR TITLE
fix: 이미지 업로드 엔드포인트 변경 및 게시글 카드 URL 추출 수정

### DIFF
--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -192,3 +192,12 @@ multipartInstance.interceptors.response.use(
   (response) => response,
   responseInterceptor,
 );
+
+// 인터셉터 설정
+multipartInstance.interceptors.request.use((config) => {
+  const token = localStorage.getItem('accessToken');
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});

--- a/src/apis/posts.ts
+++ b/src/apis/posts.ts
@@ -13,7 +13,6 @@ export interface UploadedFile {
   updatedAt: string;
   userId: string;
   fileName: string;
-  originalFileName: string;
   contentType: string;
   size: number;
 }
@@ -67,7 +66,7 @@ export const uploadMediaFiles = async (
     });
 
     const response = await multipartInstance.post<UploadedFile[]>(
-      '/posts/media',
+      '/media-files',
       formData,
     );
     return response.data;

--- a/src/components/blog/BlogPostCard.tsx
+++ b/src/components/blog/BlogPostCard.tsx
@@ -2,28 +2,39 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { Post } from '@/types/blog';
 import { formatDate } from '@/utils/date';
-import ProfileImage from '@/components/common/ProfileImage';
 
 interface BlogPostCardProps {
   post: Post;
 }
 
 export default function BlogPostCard({ post }: BlogPostCardProps) {
+  // 첫 번째 이미지 URL 추출하는 함수
+  const extractFirstImageUrl = (markdown: string) => {
+    const match = markdown.match(/!\[.*?\]\((.*?)\)/);
+    return match ? match[1] : null;
+  };
+
+  // summary에서 첫 번째 이미지 URL 추출
+  const firstImageUrl = post.summary
+    ? extractFirstImageUrl(post.summary)
+    : null;
+
   return (
     <Link href={`/posts/${post.id}`}>
       <article className="bg-white rounded-2xl overflow-hidden shadow-[0px_0px_8px_0px_rgba(0,0,0,0.02)] hover:bg-[#F7F8FA] transition-colors">
-        {/* 썸네일 이미지 */}
-        {post.thumbnail && (
-          <div className="relative w-full h-[400px]">
-            <Image
-              src={post.thumbnail}
-              alt={post.title}
-              fill
-              className="object-cover"
-              priority
-            />
-          </div>
-        )}
+        {/* 썸네일 이미지가 있을 때만 렌더링 */}
+        {(firstImageUrl || post.thumbnail) &&
+          typeof (firstImageUrl || post.thumbnail) === 'string' && (
+            <div className="relative w-full h-[400px]">
+              <Image
+                src={firstImageUrl || post.thumbnail}
+                alt={post.title}
+                fill
+                className="object-cover"
+                priority
+              />
+            </div>
+          )}
 
         {/* 컨텐츠 영역 */}
         <div className="p-8">
@@ -37,8 +48,12 @@ export default function BlogPostCard({ post }: BlogPostCardProps) {
               : formatDate(post.createdAt)}
           </time>
 
-          {/* 요약 */}
-          <p className="text-[#4D4D4D] mb-6">{post.summary}</p>
+          {/* 요약 - 이미지 마크다운을 제외한 텍스트만 표시 */}
+          {post.summary && (
+            <p className="text-[#4D4D4D] mb-6">
+              {post.summary.replace(/!\[.*?\]\(.*?\)/g, '').trim()}
+            </p>
+          )}
 
           {/* 태그 목록 */}
           <div className="flex flex-wrap gap-2">


### PR DESCRIPTION
## 변경 사항
### 엔드포인트 불일치로 인한 405 에러 해결
- /posts/media -> /media-files 로 엔드포인트 수정

### 게시글 카드에서 마크다운 텍스트가 그대로 보이는 문제 해결
- 이미지 추출 로직 추가 : 마크다운 텍스트에서 첫 번째 이미지의 URL을 추출 코드 추가
-  썸네일 표시 로직 변경 : summary에서 추출한 이미지를 우선적으로 보여주고, 없다면 thumbnail을 보여줌.
- 정규식을 사용하여 마크다운 텍스트를 직접 처리하는 방식으로 변경

## 변경 효과
- 마크다운 이미지가 텍스트로 보이는 문제 해결
- summary의 이미지가 썸네일로 표시

## 변경된 파일
- src/apis/instance.ts
- src/apis/posts.ts
- src/components/blog/BlogPostCard.tsx