### PR TITLE
fix: 디자인 시스템 수정 및 에디터/프리뷰 UI 수정 및 스타일 코드 분리

### DIFF
--- a/src/app/write/page.tsx
+++ b/src/app/write/page.tsx
@@ -129,7 +129,7 @@ export default function WritePage() {
   return (
     <div className="flex h-screen">
       {/* 왼쪽 에디터 패널 */}
-      <div className="w-1/2 flex flex-col bg-surface2">
+      <div className="w-1/2 flex flex-col bg-surface1">
         <WriteHeader
           title={postData.title}
           tags={postData.tags}
@@ -143,7 +143,7 @@ export default function WritePage() {
           <MarkdownEditor onChangeContent={handleContentChange} />
         </div>
         {/* 하단 버튼 영역 */}
-        <div className="h-12 border-t border-bg2 bg-surface2 flex items-center px-4">
+        <div className="h-12 border-t border-bg2 bg-surface1 flex items-center px-4">
           <div className="flex-1">
             <button
               onClick={() => window.history.back()}
@@ -162,7 +162,7 @@ export default function WritePage() {
             <button
               onClick={handlePublish}
               disabled={isSubmitting}
-              className="px-4 py-1.5 bg-third text-white rounded-md hover:opacity-90 disabled:opacity-50 text-sm"
+              className="px-4 py-1.5 bg-success text-white rounded-md hover:opacity-90 disabled:opacity-50 text-sm"
             >
               {isSubmitting ? '저장 중...' : '출간하기'}
             </button>
@@ -171,7 +171,7 @@ export default function WritePage() {
       </div>
 
       {/* 오른쪽 프리뷰 패널 */}
-      <div className="w-1/2">
+      <div className="w-1/2 border-l border-[#E4E6EB]">
         <MarkdownPreview
           content={postData.content}
           isPreview={true}

--- a/src/components/editor/MarkdownEditor.tsx
+++ b/src/components/editor/MarkdownEditor.tsx
@@ -2,6 +2,7 @@ import { useRef, useEffect } from 'react';
 import { Editor } from '@toast-ui/react-editor';
 import '@toast-ui/editor/dist/toastui-editor.css';
 import { uploadMediaFiles } from '@/apis/posts';
+import { MarkdownEditorStyles } from './MarkdownEditorStyles';
 
 interface MarkdownEditorProps {
   onChangeContent: (content: string) => void;
@@ -89,72 +90,7 @@ export default function MarkdownEditor({
         }}
       />
 
-      <style jsx global>{`
-        /* Write/Preview 탭 숨기기 */
-        .toastui-editor-mode-switch {
-          display: none !important;
-        }
-
-        /* 탭 컨테이너 숨기기 */
-        .toastui-editor-md-tab-container {
-          display: none !important;
-        }
-
-        /* Write/Preview 텍스트 숨기기 */
-        .toastui-editor-tabs {
-          display: none !important;
-        }
-
-        /* Preview 영역 숨기기 */
-        .toastui-editor-md-preview {
-          display: none !important;
-        }
-
-        /* 에디터 기본 스타일 */
-        .toastui-editor-defaultUI {
-          border: none !important;
-        }
-
-        .toastui-editor-toolbar {
-          border-bottom: 1px solid #e4e6eb !important;
-          padding: 8px !important;
-        }
-
-        .toastui-editor-md-container {
-          background-color: #ffffff !important;
-        }
-
-        .toastui-editor-md-container .toastui-editor {
-          background-color: #ffffff !important;
-          padding: 24px !important;
-        }
-
-        .toastui-editor-contents {
-          font-size: 16px !important;
-          font-family:
-            Pretendard,
-            -apple-system,
-            BlinkMacSystemFont,
-            system-ui,
-            sans-serif !important;
-        }
-
-        /* 에디터 내 코드 블록 관련 스타일 제거 */
-        .toastui-editor-contents pre {
-          background: none !important;
-          padding: 0 !important;
-        }
-
-        /* 인라인 코드 스타일 */
-        .toastui-editor-contents code {
-          background-color: #f2f3f5 !important;
-          color: #666666 !important;
-          padding: 0.2em 0.4em !important;
-          border-radius: 4px !important;
-          font-size: 14px !important;
-          font-family: Pretendard !important;
-        }
-      `}</style>
+      <MarkdownEditorStyles />
     </div>
   );
 }

--- a/src/components/editor/MarkdownEditorStyles.tsx
+++ b/src/components/editor/MarkdownEditorStyles.tsx
@@ -1,0 +1,68 @@
+export const MarkdownEditorStyles = () => (
+  <style jsx global>{`
+    /* Write/Preview 탭 숨기기 */
+    .toastui-editor-mode-switch {
+      display: none !important;
+    }
+
+    /* 탭 컨테이너 숨기기 */
+    .toastui-editor-md-tab-container {
+      display: none !important;
+    }
+
+    /* Write/Preview 텍스트 숨기기 */
+    .toastui-editor-tabs {
+      display: none !important;
+    }
+
+    /* Preview 영역 숨기기 */
+    .toastui-editor-md-preview {
+      display: none !important;
+    }
+
+    /* 에디터 기본 스타일 */
+    .toastui-editor-defaultUI {
+      border: none !important;
+    }
+
+    .toastui-editor-toolbar {
+      border-bottom: 1px solid #e4e6eb !important;
+      padding: 8px !important;
+    }
+
+    .toastui-editor-md-container {
+      background-color: #fcfcfc !important;
+    }
+
+    .toastui-editor-md-container .toastui-editor {
+      background-color: #fcfcfc !important;
+      padding: 24px !important;
+    }
+
+    .toastui-editor-contents {
+      font-size: 16px !important;
+      font-family:
+        Pretendard,
+        -apple-system,
+        BlinkMacSystemFont,
+        system-ui,
+        sans-serif !important;
+    }
+
+    /* 에디터 내 코드 블록 관련 스타일 제거 */
+    .toastui-editor-contents pre {
+      background: none !important;
+      padding: 0 !important;
+    }
+
+    /* 인라인 코드 스타일 */
+    .toastui-editor-contents code {
+      background-color: #f2f3f5 !important;
+      color: #666666 !important;
+      padding: 0.2em 0.4em !important;
+      border-radius: 4px !important;
+      font-size: 14px !important;
+      font-family: Pretendard !important;
+    }
+  `}</style>
+);

--- a/src/components/editor/MarkdownPreview.tsx
+++ b/src/components/editor/MarkdownPreview.tsx
@@ -9,6 +9,7 @@ import { PrismLight as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { oneLight } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import type { Components } from 'react-markdown';
 import { TocItem } from '@/types/blog';
+import { MarkdownPreviewStyles } from './MarkdownPreviewStyles';
 
 interface MarkdownPreviewProps {
   content: string;
@@ -50,27 +51,27 @@ const MarkdownPreview = ({
 }: MarkdownPreviewProps) => {
   // 디버깅을 위한 로그
   useEffect(() => {
-    console.log('MarkdownPreview 마운트, tocItems:', tocItems);
+    // console.log('MarkdownPreview 마운트, tocItems:', tocItems);
 
     // 마운트 후 잠시 대기 후 헤딩 ID 확인 (렌더링 완료 후)
     setTimeout(() => {
       const headings = document.querySelectorAll('h1, h2, h3');
-      console.log('렌더링된 헤딩 요소 수:', headings.length);
-      console.log('헤딩 요소:');
+      // console.log('렌더링된 헤딩 요소 수:', headings.length);
+      // console.log('헤딩 요소:');
       headings.forEach((h) => {
-        console.log(
-          `${h.tagName}: id="${h.id}", text="${h.textContent?.trim()}"`,
-        );
+        // console.log(
+        //   `${h.tagName}: id="${h.id}", text="${h.textContent?.trim()}"`,
+        // );
       });
 
       // TOC에서 사용하는 ID를 가진 요소가 있는지 확인
       if (tocItems.length > 0) {
-        console.log('TOC 항목에 대응하는 헤딩 요소 확인:');
+        // console.log('TOC 항목에 대응하는 헤딩 요소 확인:');
         tocItems.forEach((item) => {
           const element = document.getElementById(item.id);
-          console.log(
-            `TOC ID "${item.id}" (${item.text}): ${element ? '요소 찾음' : '요소 없음'}`,
-          );
+          // console.log(
+          //   `TOC ID "${item.id}" (${item.text}): ${element ? '요소 찾음' : '요소 없음'}`,
+          // );
         });
       }
     }, 500);
@@ -137,7 +138,7 @@ const MarkdownPreview = ({
 
   // 헤딩 처리를 위한 함수 - TOC 항목의 ID를 그대로 사용
   const createHeadingComponent = (level: number) => {
-    return ({ node, children, ...props }: any) => {
+    const HeadingComponent = ({ node, children, ...props }: any) => {
       // 헤딩 텍스트 얻기
       const text = String(children).replace(/\s+/g, ' ').trim();
 
@@ -151,7 +152,7 @@ const MarkdownPreview = ({
         ? matchingTocItem.id
         : `heading-auto-${level}-${text.slice(0, 20).toLowerCase().replace(/\s+/g, '-')}`;
 
-      console.log(`헤딩 렌더링: level=${level}, text="${text}", id="${id}"`);
+      // console.log(`헤딩 렌더링: level=${level}, text="${text}", id="${id}"`);
 
       let className;
       if (level === 1) {
@@ -170,6 +171,10 @@ const MarkdownPreview = ({
         </HeadingTag>
       );
     };
+
+    HeadingComponent.displayName = `Heading${level}`;
+
+    return HeadingComponent;
   };
 
   const components: Components = {
@@ -218,7 +223,7 @@ const MarkdownPreview = ({
 
   return (
     <div
-      className={`h-full overflow-y-auto px-8 py-6 ${isPreview ? 'bg-surface1' : 'bg-white'}`}
+      className={`h-full overflow-y-auto px-8 py-6 ${isPreview ? 'bg-[#FCFCFC]' : 'bg-white'}`}
     >
       {/* 프리뷰 모드일 때만 제목 표시 */}
       {isPreview && (
@@ -236,158 +241,7 @@ const MarkdownPreview = ({
         </ReactMarkdown>
       </div>
 
-      <style jsx global>{`
-        /* 기존 스타일 동일하게 유지 */
-        .code-block-wrapper {
-          margin: 1.5em 0;
-          background: #ffffff;
-          border: 1px solid #e4e6eb;
-          border-radius: 8px;
-          overflow: hidden;
-        }
-
-        .code-block-header {
-          position: relative;
-          height: 32px;
-          background: #f9f9f9;
-          display: flex;
-          align-items: center;
-          padding: 0 12px;
-          border-bottom: 1px solid #e4e6eb;
-        }
-
-        .mac-buttons {
-          display: flex;
-          gap: 8px;
-        }
-
-        .mac-button {
-          width: 12px;
-          height: 12px;
-          border-radius: 50%;
-        }
-
-        .mac-button.close {
-          background-color: #ff5f56;
-        }
-
-        .mac-button.minimize {
-          background-color: #ffbd2e;
-        }
-
-        .mac-button.maximize {
-          background-color: #27c93f;
-        }
-
-        .language-label {
-          position: absolute;
-          left: auto;
-          right: 12px;
-          transform: translateY(-50%);
-          top: 50%;
-          font-size: 12px;
-          color: #666666;
-          font-weight: 500;
-        }
-
-        /* prose 스타일 재정의 */
-        .prose {
-          max-width: none;
-        }
-
-        .prose pre {
-          margin: 0 !important;
-          padding: 0 !important;
-          background: transparent !important;
-        }
-
-        .prose img {
-          border-radius: 8px;
-          margin: 24px 0;
-        }
-
-        .prose hr {
-          border-color: #e4e6eb;
-          margin: 24px 0;
-        }
-
-        /* 코드 블록 내부 스타일 */
-        .code-block-content {
-          background: #ffffff;
-          overflow-x: auto;
-          max-width: 790px;
-        }
-
-        .code-block-content > div {
-          background: #ffffff !important;
-        }
-
-        .code-block-content code {
-          background: none !important;
-        }
-
-        .code-block-content span {
-          background: none !important;
-        }
-
-        /* 인라인 코드 스타일 */
-        :not(pre) > code {
-          background-color: #f2f3f5 !important;
-          color: #666666 !important;
-          padding: 0.2em 0.4em !important;
-          border-radius: 4px !important;
-          font-size: 14px !important;
-          font-family: Pretendard !important;
-        }
-
-        /* 코드 블록 들여쓰기 관련 스타일 추가 */
-        .code-block-content pre {
-          tab-size: 2 !important;
-          -moz-tab-size: 2 !important;
-          -o-tab-size: 2 !important;
-          -webkit-tab-size: 2 !important;
-          width: max-content;
-          min-width: 100%;
-        }
-
-        .code-block-content code {
-          font-family: 'Pretendard Mono', Consolas, Monaco, monospace !important;
-          white-space: pre !important;
-          word-spacing: normal !important;
-          word-break: normal !important;
-          word-wrap: normal !important;
-          line-height: 1.5 !important;
-        }
-
-        /* 라인 넘버 스타일 */
-        .linenumber {
-          min-width: 2.5em !important;
-          padding-right: 1em !important;
-          text-align: right !important;
-          color: #999999 !important;
-          user-select: none !important;
-        }
-
-        /* 스크롤바 커스텀 스타일링 */
-        .code-block-content::-webkit-scrollbar {
-          height: 6px;
-        }
-
-        .code-block-content::-webkit-scrollbar-track {
-          background: #f2f3f5;
-          border-radius: 3px;
-        }
-
-        .code-block-content::-webkit-scrollbar-thumb {
-          background: #e4e6eb;
-          border-radius: 3px;
-          transition: background-color 0.2s ease;
-        }
-
-        .code-block-content::-webkit-scrollbar-thumb:hover {
-          background: #999999;
-        }
-      `}</style>
+      <MarkdownPreviewStyles />
     </div>
   );
 };

--- a/src/components/editor/MarkdownPreviewStyles.tsx
+++ b/src/components/editor/MarkdownPreviewStyles.tsx
@@ -1,0 +1,155 @@
+export const MarkdownPreviewStyles = () => (
+  <style jsx global>{`
+    /* 코드 블록 스타일 */
+    .code-block-wrapper {
+      margin: 1.5em 0;
+      background: #fcfcfc;
+      border: 1px solid #e4e6eb;
+      border-radius: 8px;
+      overflow: hidden;
+      box-shadow: 0px 0px 16px 0px rgba(0, 0, 0, 0.06);
+    }
+
+    .code-block-header {
+      position: relative;
+      height: 32px;
+      background: #f9f9f9;
+      display: flex;
+      align-items: center;
+      padding: 0 12px;
+      border-bottom: 1px solid #e4e6eb;
+    }
+
+    .mac-buttons {
+      display: flex;
+      gap: 8px;
+    }
+
+    .mac-button {
+      width: 12px;
+      height: 12px;
+      border-radius: 50%;
+    }
+
+    .mac-button.close {
+      background-color: #ff5f56;
+    }
+
+    .mac-button.minimize {
+      background-color: #ffbd2e;
+    }
+
+    .mac-button.maximize {
+      background-color: #27c93f;
+    }
+
+    .language-label {
+      position: absolute;
+      left: auto;
+      right: 12px;
+      transform: translateY(-50%);
+      top: 50%;
+      font-size: 12px;
+      color: #666666;
+      font-weight: 500;
+    }
+
+    /* prose 스타일 재정의 */
+    .prose {
+      max-width: none;
+    }
+
+    .prose pre {
+      margin: 0 !important;
+      padding: 0 !important;
+      background: transparent !important;
+    }
+
+    .prose img {
+      border-radius: 8px;
+      margin: 24px 0;
+    }
+
+    .prose hr {
+      border-color: #e4e6eb;
+      margin: 24px 0;
+    }
+
+    /* 코드 블록 내부 스타일 */
+    .code-block-content {
+      background: #fcfcfc;
+      overflow-x: auto;
+      max-width: 790px;
+    }
+
+    .code-block-content > div {
+      background: #fcfcfc !important;
+    }
+
+    .code-block-content code {
+      background: none !important;
+    }
+
+    .code-block-content span {
+      background: none !important;
+    }
+
+    /* 인라인 코드 스타일 */
+    :not(pre) > code {
+      background-color: #f2f3f5 !important;
+      color: #666666 !important;
+      padding: 0.2em 0.4em !important;
+      border-radius: 4px !important;
+      font-size: 14px !important;
+      font-family: Pretendard !important;
+    }
+
+    /* 코드 블록 들여쓰기 관련 스타일 추가 */
+    .code-block-content pre {
+      tab-size: 2 !important;
+      -moz-tab-size: 2 !important;
+      -o-tab-size: 2 !important;
+      -webkit-tab-size: 2 !important;
+      width: max-content;
+      min-width: 100%;
+    }
+
+    .code-block-content code {
+      font-family: 'Pretendard Mono', Consolas, Monaco, monospace !important;
+      white-space: pre !important;
+      word-spacing: normal !important;
+      word-break: normal !important;
+      word-wrap: normal !important;
+      line-height: 1.5 !important;
+    }
+
+    /* 라인 넘버 스타일 */
+    .linenumber {
+      min-width: 2.5em !important;
+      padding-right: 1em !important;
+      text-align: right !important;
+      color: #999999 !important;
+      user-select: none !important;
+    }
+
+    /* 스크롤바 커스텀 스타일링 */
+    .code-block-content::-webkit-scrollbar {
+      height: 6px;
+    }
+
+    .code-block-content::-webkit-scrollbar-track {
+      background: #f2f3f5;
+      border-radius: 3px;
+    }
+
+    .code-block-content::-webkit-scrollbar-thumb {
+      background: #e4e6eb;
+      border-radius: 3px;
+      transition: background-color 0.2s ease;
+    }
+
+    .code-block-content::-webkit-scrollbar-thumb:hover {
+      background: #999999;
+    }
+  `}</style>
+);

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -16,12 +16,13 @@ const config: Config = {
         // Background colors
         bg: '#F2F3F5',
         'bg-2': '#E4E6EB',
-        surface1: '#F9F9F9',
+        surface1: '#FCFCFC',
         surface2: '#FFFFFF',
+        'surface-hover': '#F7F8FA',
         // State colors
-        error: '#F73322',
-        warning: '#E73322',
-        success: '#3EC292',
+        error: '#F44336',
+        warning: '#FFC107',
+        success: '#4CAF50',
         'success-2': '#388E3C',
         info: '#2196F3',
         // Font colors


### PR DESCRIPTION
# 디자인 시스템 수정 및 에디터/프리뷰 UI 수정 및 스타일 코드 분리

## 개요
디자인 시스템의 색상 변경에 따른 디자인 시스템 색상 정의를 수정하고, 그에 따른 에디터/프리뷰에 디자인 시스템 색상 적용하고 에디터와 프리뷰의 가독성과 유지보수를 위해 스타일 코드 분리함.

## 상세 구현 내용

### 1. tailwind.config.ts 파일 디자인 시스템 변경
- 디자인 시스템 색상 정의 수정(Surface1, Error, Success 등)

### 2. 에디터/프리뷰 UI 개선
- 에디터 패널 배경색을 Surface1(#FCFCFC)로 변경
- 프리뷰 패널과 에디터 패널 사이에 경계선 추가
- 코드 블록에 그림자 효과 추가

### 3. 에디터/프리뷰 코드 구조 개선
- 스타일 코드를 별도로 컴포넌트로 분리(MarkdownEditorStyles, MarkdownPreviewStyles)
- 디버깅용 console.log 주석 처리
- 컴포넌트 displayName 추가로 경고 해결

## 변경된 파일 목록
- `src/app/write/page.tsx` (수정)
-  `src/components/editor/MarkdownEditor.tsx (수정)`
- `src/components/editor/MarkdownPreview.tsx` (수정)
- `src/components/editor/MarkdownPreviewStyles.tsx` (추가)
-  `src/components/editor/MarkdownPreviewStyles.tsx` (추가)
-  `tailwind.config.ts` (수정)