### PR TITLE
feat: 로그인 페이지에 토스트 메시지 적용

### DIFF
--- a/src/app/(auth)/login/password/page.tsx
+++ b/src/app/(auth)/login/password/page.tsx
@@ -11,6 +11,7 @@ import type { ApiError } from '@/types/auth';
 import axios from 'axios';
 import { useRecoilState } from 'recoil';
 import { authState, initializeAuthState } from '@/store/auth';
+import { useToast } from '@/contexts/ToastContext';
 
 export default function LoginPasswordPage() {
   const router = useRouter();
@@ -19,6 +20,7 @@ export default function LoginPasswordPage() {
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [auth, setAuth] = useRecoilState(authState);
+  const { showToast } = useToast();
 
   useEffect(() => {
     const storedEmail = localStorage.getItem('tempEmail');
@@ -47,6 +49,12 @@ export default function LoginPasswordPage() {
       // 임시 데이터 삭제
       localStorage.removeItem('tempEmail');
 
+      // 로그인 성공 토스트 메시지 표시
+      showToast('success', {
+        title: '로그인 성공',
+        description: '모하지 스튜디오에 오신 것을 환영합니다!',
+      });
+
       // 홈으로 이동
       router.push('/');
     } catch (error) {
@@ -54,11 +62,32 @@ export default function LoginPasswordPage() {
 
       if (axios.isAxiosError(error)) {
         const apiError = error.response?.data as ApiError;
-        setError(getAuthErrorMessage(apiError));
+        const errorMessage = getAuthErrorMessage(apiError);
+        setError(errorMessage);
+
+        // 로그인 실패 토스트 메시지 표시
+        showToast('error', {
+          title: '로그인 실패',
+          description: errorMessage,
+        });
       } else if (error instanceof Error) {
         setError(error.message);
+
+        // 로그인 실패 토스트 메시지 표시
+        showToast('error', {
+          title: '로그인 실패',
+          description: error.message,
+        });
       } else {
-        setError('로그인에 실패했습니다. 잠시 후 다시 시도해주세요.');
+        const defaultErrorMsg =
+          '로그인에 실패했습니다. 잠시 후 다시 시도해주세요.';
+        setError(defaultErrorMsg);
+
+        // 로그인 실패 토스트 메시지 표시
+        showToast('error', {
+          title: '로그인 실패',
+          description: defaultErrorMsg,
+        });
       }
     } finally {
       setIsLoading(false);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,16 +3,28 @@
 import { pretendard } from '@/styles/fonts';
 import './globals.css';
 import Providers from './providers';
+import { useEffect, useState } from 'react';
+import { RecoilRoot } from 'recoil';
 
 export default function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  // 클라이언트 사이드 렌더링을 위한 상태 추가
+  const [mounted, setMounted] = useState(false);
+
+  // 컴포넌트가 마운트된 후에만 렌더링
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
   return (
     <html lang="ko" className={pretendard.variable}>
       <body>
-        <Providers>{children}</Providers>
+        <RecoilRoot>
+          {!mounted ? children : <Providers>{children}</Providers>}
+        </RecoilRoot>
       </body>
     </html>
   );


### PR DESCRIPTION
## 개요
로그인 페이지에 토스트 메시지를 적용하여 사용자에게 로그인 성공/실패에 대한 피드백을 제공합니다.

## 상세 구현 내용
- 로그인 성공 시 success 토스트 메시지 표시
- 로그인 실패 시 error 토스트 메시지 표시 (다양한 에러 케이스 처리)
- 토스트 메시지 위치를 상단 중앙으로 설정하여 가시성 향상
- 줄바꿈 기능 적용으로 가독성 개선
- RecoilRoot 관련 이슈 해결을 위한 layout.tsx 수정